### PR TITLE
ES-975464 - Resolve the ReadMe file length issue in this sample repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# how_to_discard_all_changes
+# How to discard all changes
 
 This sample explains how to undo and redo all the unsaved changes in [WPF Spreadsheet](https://www.syncfusion.com/wpf-controls/spreadsheet).
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# How to discard all changes
+# How to Discard all the Changes in WPF Spreadsheet?
 
-This sample explains how to undo and redo all the unsaved changes in [WPF Spreadsheet](https://www.syncfusion.com/wpf-controls/spreadsheet).
+This sample explains how to undo and redo all the unsaved changes in [WPF Spreadsheet](https://www.syncfusion.com/wpf-controls/spreadsheet) (SfSpreadsheet).
 
-By default, all the unsaved changes are maintained in the `UndoStack` commands collection.  To discard all the unsaved changes programmatically, `Execute` the all commands in `UndoStack` collection. By executing the commands in `RedoStack` commands collection, all the discarded changes can be retrieved.
+By default, all the unsaved changes are maintained in the **UndoStack** commands collection.  To discard all the unsaved changes programmatically, **Execute** the all commands in **UndoStack** collection. By executing the commands in **RedoStack** commands collection, all the discarded changes can be retrieved.
 
 ``` c#
 //UndoAll the changes

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # how_to_discard_all_changes
-This sample explains how to undo and redo all the unsaved changes in Spreadsheet
+
+This sample explains how to undo and redo all the unsaved changes in [WPF Spreadsheet](https://www.syncfusion.com/wpf-controls/spreadsheet).
+
+By default, all the unsaved changes are maintained in the `UndoStack` commands collection.  To discard all the unsaved changes programmatically, `Execute` the all commands in `UndoStack` collection. By executing the commands in `RedoStack` commands collection, all the discarded changes can be retrieved.
+
+``` c#
+//UndoAll the changes
+while (this.spreadsheetControl.HistoryManager.UndoStack.Count > 0) 
+{ 
+   var undo = this.spreadsheetControl.HistoryManager.UndoStack.Pop(); 
+   if (undo != null) 
+   { 
+        undo.Execute(Syncfusion.UI.Xaml.Spreadsheet.History.CommandMode.Undo); 
+   } 
+}
+ 
+//RedoAll the changes
+while (this.spreadsheetControl.HistoryManager.RedoStack.Count > 0) 
+{ 
+    var redo = this.spreadsheetControl.HistoryManager.RedoStack.Pop(); 
+    if (redo != null) 
+    {
+        redo.Execute(Syncfusion.UI.Xaml.Spreadsheet.History.CommandMode.Redo); 
+    }
+}
+```


### PR DESCRIPTION
## Description: ##

Resolved the ReadMe length issue in this sample repository. 

**Task:** [Task 975464 Resolve Issues in Public Syncfusion Code Examples for DataGrid XAML Controls](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/975464)

## Preview Image: ##

<img width="885" height="624" alt="image" src="https://github.com/user-attachments/assets/2fb732cf-19ab-46b3-b8ee-e55f4e213a0f" />

UG link: https://support.syncfusion.com/kb/article/9329/how-to-discard-all-the-changes-in-sfspreadsheet
